### PR TITLE
Add Scala 2.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,56 @@
 
 # Introduction
 
-The Jooq-scala-macro project consists of a public type provider for scala which generates immutable scala classes based on the standard generated jooq meta-model classes
+The `jooq-scala-macro` project consists of a public type provider for Scala which generates immutable Scala classes based on the standard generated JOOQ meta-model classes.
 
-Implicit conversions are also provided to go to/from the java and scala representations, and the companion object for a table extends the `org.jooq.Table` implementation allowing the companion to be used in Jooq queries
+Implicit conversions are also provided to go to/from the Java and Scala representations, and the companion object for a table extends the `org.jooq.Table` implementation allowing the companion to be used in JOOQ queries.
 
 More detailed documentation is being worked on, in the meantime feel free to ask questions in the [Gitter Channel](https://gitter.im/streetcontxt/Lobby).
+
+# Scala & Jooq versions support
+
+Version 13.0:
+
+| Scala version | JOOQ version |
+|---------------|--------------|
+|    2.11.x     |   ≥ 3.10.2   |
+|    2.12.x     |   ≥ 3.10.2   |
+
+
+Version 13.1+:
+
+| Scala version | JOOQ version |
+|---------------|--------------|
+|    2.11.x     |   ≥ 3.10.8   |
+|    2.12.x     |   ≥ 3.10.8   |
+|    2.13.x*    |   ≥ 3.13.    |
+
+\* JOOQ configuration notes for Scala 2.13.x & JOOQ 3.13.x:
+
+The JOOQ code generation process default settings has an important change in v3.13. By default, array types were using varargs setters in versions 3.9..3.12, but then this has been switched to collections in 3.13.
+
+The macro code does not have any knowledge about the settings used in generation, and assumes the varargs setters for backward compatibility, which could generate an incompatible code:
+```
+... type mismatch;
+[error]  found   : Array[String]
+[error]  required: Array[_ <: Array[String]]
+[error] @fromCatalog[DefaultCatalog]
+```
+
+To fix the above error, the varargs setters should be explicitly enabled in JOOQ codegen configuration in the client code:
+
+```xml
+<configuration>
+    ...
+    <generator>
+        ...
+        <generate>
+            <varargSetters>true</varargSetters>
+        </generate>
+    </generator>
+</configuration>
+
+```
 
 # Example Code
 
@@ -44,4 +89,4 @@ Our [Gitter](https://gitter.im/streetcontxt/Lobby) channel can be used to ask qu
 
 # Note
 
-This project was written separately from the Jooq project, our use of the name shouldn't be taken as any sort of endorsment from the developers of that library.
+This project was written separately from the JOOQ project, our use of the name shouldn't be taken as any sort of endorsement from the developers of that library.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version=1.3.13

--- a/src/main/scala/com/streetcontxt/db/JooqGenerator.scala
+++ b/src/main/scala/com/streetcontxt/db/JooqGenerator.scala
@@ -7,11 +7,11 @@ import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
 class fromCatalog[C <: org.jooq.Catalog] extends StaticAnnotation {
-  def macroTransform(annottees: Any*) = macro JooqGenerator.fromCatalog_impl
+  def macroTransform(annottees: Any*): Any = macro JooqGenerator.fromCatalog_impl
 }
 
 class fromSchema[C <: org.jooq.Catalog] extends StaticAnnotation {
-  def macroTransform(annottees: Any*) = macro JooqGenerator.fromSchema_impl
+  def macroTransform(annottees: Any*): Any  = macro JooqGenerator.fromSchema_impl
 }
 
 class JooqGenerator(val c: whitebox.Context) {
@@ -92,12 +92,12 @@ class JooqGenerator(val c: whitebox.Context) {
           """
         val defaultCtorPos = c.enclosingPosition
         val modCtorPos = defaultCtorPos
-          .withEnd(defaultCtorPos.endOrPoint + 1)
-          .withStart(defaultCtorPos.startOrPoint + 1)
+          .withEnd(defaultCtorPos.end + 1)
+          .withStart(defaultCtorPos.start + 1)
           .withPoint(defaultCtorPos.point + 1)
         val recCtorPos = modCtorPos
-          .withEnd(modCtorPos.endOrPoint + 1)
-          .withStart(modCtorPos.startOrPoint + 1)
+          .withEnd(modCtorPos.end + 1)
+          .withStart(modCtorPos.start + 1)
           .withPoint(modCtorPos.point + 1)
         val newBody = body :+ atPos(modCtorPos)(modCtor) :+ atPos(recCtorPos)(recCtor)
         q"case class $typeName (..$fieldDefs) extends JooqRecordLike[$recordType] { ..$newBody }"
@@ -275,7 +275,7 @@ class JooqGenerator(val c: whitebox.Context) {
           q"""
           object $name {
             import scala.language.implicitConversions
-            import scala.collection.JavaConverters._
+            import scala.jdk.CollectionConverters._
 
             trait JooqRecordLike[R <: org.jooq.Record] {
               def record: R
@@ -315,7 +315,7 @@ class JooqGenerator(val c: whitebox.Context) {
           q"""
             object $name {
               import scala.language.implicitConversions
-              import scala.collection.JavaConverters._
+              import scala.jdk.CollectionConverters._
 
               trait JooqRecordLike[R <: org.jooq.Record] {
                 def record: R


### PR DESCRIPTION
This PR add a cross-compile build option for Scala 2.13 & JOOQ 3.13 in a backward-compatible way, see `README.md` for details. 
I'm thinking to release it as v13.1

Note: builds for Scala <2.13 will pull additional dependency `org.scala-lang.modules:scala-collection-compat` due to switch to `scala.jdk.CollectionConverters` in generator in order to avoid warnings in 2.13+
